### PR TITLE
Set Cookie for older ASP.NET

### DIFF
--- a/aspnet.md
+++ b/aspnet.md
@@ -1,6 +1,6 @@
 # ASP.NET and ASP.NET Core
 
-See the annoucements here: <br>
+See the announcements here: <br>
 https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/ <br>
 https://github.com/aspnet/Announcements/issues/390 <br>
 

--- a/crosssite-embed.html
+++ b/crosssite-embed.html
@@ -6,8 +6,9 @@
 <p>Testing cross-site cookies</p>
 <script>
   var req = new XMLHttpRequest();
+  req.withCredentials = true;
   req.responseType = 'json';
-  req.open('GET', url, true);
+  req.open('GET', "https://samesite-sandbox.glitch.me/cookies.json", true);
   req.onload  = function() {
      var jsonResponse = req.response;
      window.parent.postMessage(data, "https://samesite-sandbox.glitch.me");

--- a/crosssite-embed.html
+++ b/crosssite-embed.html
@@ -11,7 +11,7 @@
   req.open('GET', "https://samesite-sandbox.glitch.me/cookies.json", true);
   req.onload  = function() {
      var jsonResponse = req.response;
-     window.parent.postMessage(data, "https://samesite-sandbox.glitch.me");
+     window.parent.postMessage(jsonResponse, "https://samesite-sandbox.glitch.me");
   };
   req.send(null);
 </script>

--- a/crosssite-embed.html
+++ b/crosssite-embed.html
@@ -5,14 +5,12 @@
 <title>Cross-site 🍪 sandbox</title>
 <p>Testing cross-site cookies</p>
 <script>
-  async function sendcookies() {
-    const response = await fetch(
-      "https://samesite-sandbox.glitch.me/cookies.json",
-      { credentials: "include" }
-    );
-    const data = await response.json();
-    window.top.postMessage(data, "https://samesite-sandbox.glitch.me");
-  }
-
-  sendcookies();
+  var req = new XMLHttpRequest();
+  req.responseType = 'json';
+  req.open('GET', url, true);
+  req.onload  = function() {
+     var jsonResponse = req.response;
+     window.parent.postMessage(data, "https://samesite-sandbox.glitch.me");
+  };
+  req.send(null);
 </script>

--- a/crosssite-embed.html
+++ b/crosssite-embed.html
@@ -18,5 +18,4 @@
   }
   
   fetchCookies('GET');
-  fetchCookies('POST');
 </script>

--- a/crosssite-embed.html
+++ b/crosssite-embed.html
@@ -11,7 +11,7 @@
     req.responseType = 'json';
     req.open(requestMethod, "https://samesite-sandbox.glitch.me/cookies.json", true);
     req.onload  = function() {
-       var jsonResponse = { type: requestMethod, cookies: req.response };
+       var jsonResponse = { method: requestMethod, cookies: req.response };
        window.parent.postMessage(jsonResponse, "https://samesite-sandbox.glitch.me");
     };
     req.send(null);

--- a/crosssite-embed.html
+++ b/crosssite-embed.html
@@ -5,13 +5,18 @@
 <title>Cross-site 🍪 sandbox</title>
 <p>Testing cross-site cookies</p>
 <script>
-  var req = new XMLHttpRequest();
-  req.withCredentials = true;
-  req.responseType = 'json';
-  req.open('GET', "https://samesite-sandbox.glitch.me/cookies.json", true);
-  req.onload  = function() {
-     var jsonResponse = req.response;
-     window.parent.postMessage(jsonResponse, "https://samesite-sandbox.glitch.me");
-  };
-  req.send(null);
+  function fetchCookies(requestMethod) {
+    var req = new XMLHttpRequest();
+    req.withCredentials = true;
+    req.responseType = 'json';
+    req.open(requestMethod, "https://samesite-sandbox.glitch.me/cookies.json", true);
+    req.onload  = function() {
+       var jsonResponse = { type: requestMethod, cookies: req.response };
+       window.parent.postMessage(jsonResponse, "https://samesite-sandbox.glitch.me");
+    };
+    req.send(null);
+  }
+  
+  fetchCookies('GET');
+  fetchCookies('POST');
 </script>


### PR DESCRIPTION
Current same site cookie examples are for ASP.NET 4.7.2 and up. The SameSite property is not supported in prior (< 4.7.2) versions of ASP.NET. 