### PR TITLE
Add example for ASP.NET prior to 4.7.2.

### DIFF
--- a/aspnet.md
+++ b/aspnet.md
@@ -27,3 +27,13 @@ Response.Cookies.Append("Key", "Value", new CookieOptions()
 });
 ```
 
+## < ASP.NET 4.7.2
+Cookie needs to be overwritten with the appropriate attributes set in the Global.asax:
+```
+void PreSendRequestHeaders(object sender, EventArgs e)
+{
+    HttpApplication app = sender as HttpApplication;
+    if (app != null && app.Context.SkipAuthorization && app.Request.Cookies["ASP.NET_SessionId"] != null)
+        app.Response.AddHeader("Set-Cookie", "ASP.NET_SessionId=" + app.Request.Cookies["ASP.NET_SessionId"].Value + ";HttpOnly;SameSite=None;Secure");
+}
+```


### PR DESCRIPTION
ASP.NET prior to 4.7.2 do not support the SameSite attribute of the HttpCookie object. Therefore, the cookie needs to be overwritten using the Set-Cookie header with the samesite attribute added.