### PR TITLE
Fix invalid PHP code example

### DIFF
--- a/php.md
+++ b/php.md
@@ -38,7 +38,7 @@ For Session Cookie , you can set into [`session_set_cookie_params`](https://www.
 PHP 7.3.0 introduced new attributes for samesite.
 
 ```php
-if (PHP_VERSION_ID < 70300) { 
+if (PHP_VERSION_ID >= 70300) { 
 session_set_cookie_params([
     'lifetime' => $cookie_timeout,
     'path' => '/',
@@ -48,12 +48,12 @@ session_set_cookie_params([
     'samesite' => 'Lax'
 ]);
 } else { 
-session_set_cookie_params([
-    'lifetime' => $cookie_timeout,
-    'path' => '/; samesite=Lax',
-    'domain' => $cookie_domain,
-    'secure' => $session_secure,
-    'httponly' => $cookie_httponly
-]);
+session_set_cookie_params(
+    $cookie_timeout,
+    '/; samesite=Lax',
+    $cookie_domain,
+    $session_secure,
+    $cookie_httponly
+);
 }
 ```


### PR DESCRIPTION
The `samesite` config was added in PHP 7.3, so the `if` check was the wrong way round.
Prior to 7.3 `session_set_cookie_params` didn't accept an array so this would have resulted in an error (https://3v4l.org/YKFrE). Changed to separate parameters. There are no longer any errors (https://3v4l.org/C0nGT)